### PR TITLE
hacked on darwin support by just always checking %*ENV<HOME> first

### DIFF
--- a/lib/File/HomeDir.pm
+++ b/lib/File/HomeDir.pm
@@ -1,6 +1,10 @@
 class File::HomeDir;
 
 method my_home {
+    # Try HOME on every platform first, because even on Windows, some
+    # unix-style utilities rely on the ability to overload HOME.
+    return %*ENV<HOME> if %*ENV<HOME>;
+
     given $*OS {
         when 'MSWin32' {
             return %*ENV<HOMEDRIVE> ~ %*ENV<HOMEPATH>


### PR DESCRIPTION
which is essentially the way Perl 5 File::HomeDir does it, because of some programs that set $HOME even on windows.
