### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/File/HomeDir.pm
+++ b/lib/File/HomeDir.pm
@@ -1,4 +1,4 @@
-class File::HomeDir;
+unit class File::HomeDir;
 
 method my_home {
     # Try HOME on every platform first, because even on Windows, some


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.
